### PR TITLE
Create Execution Role for Lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+info.txt
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.17.0"
+  hashes = [
+    "h1:U+EDfeUqefebA1h7KyBMD1xH0h311LMi7wijPDPkC/0=",
+    "zh:0087b9dd2c9c638fd63e527e5b9b70988008e263d480a199f180efe5a4f070f0",
+    "zh:0fd532a4fd03ddef11f0502ff9fe4343443e1ae805cb088825a71d6d48906ec7",
+    "zh:16411e731100cd15f7e165f53c23be784b2c86c2fcfd34781e0642d17090d342",
+    "zh:251d520927e77f091e2ec6302e921d839a2430ac541c6a461aed7c08fb5eae12",
+    "zh:4919e69682dc2a8c32d44f6ebc038a52c9f40af9c61cb574b64e322800d6a794",
+    "zh:5334c60759d5f76bdc51355d1a3ebcc451d4d20f632f5c73b6e55c52b5dc9e52",
+    "zh:7341a2b7247572eba0d0486094a870b872967702ec0ac7af728c2df2c30af4e5",
+    "zh:81d1b1cb2cac6b3922a05adab69543b678f344a01debd54500263700dad7a288",
+    "zh:882bc8e15ef6d4020a07321ec4c056977c5c1d96934118032922561d29504d43",
+    "zh:8cd4871ef2b03fd916de1a6dc7eb8a81a354c421177d4334a2e3308e50215e41",
+    "zh:97e12fe6529b21298adf1046c5e20ac35d0569c836a6f385ff041e257e00cfd2",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f5baf5d59b9f3cf5504d1fa975f10f27da3791896a9e18ece47c258bac17634",
+    "zh:dffafba6731ac1db1c540bdbd6a8c878486b71de9d0ca1d23c5c00a6c3c14d80",
+    "zh:fa7440c3c15a42fc5731444d324ced75407d417bfe3184661ae47d40a9718dce",
+  ]
+}

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,18 @@
+###########################################
+############### RESOURCES #################
+###########################################
+
+# Allow Lambda to assume this role.
+data "aws_iam_policy_document" "lambda-trust-policy-doc" {
+  statement {
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}

--- a/data.tf
+++ b/data.tf
@@ -16,3 +16,18 @@ data "aws_iam_policy_document" "lambda-trust-policy-doc" {
     actions = ["sts:AssumeRole"]
   }
 }
+
+# Allow Lambda to send logs to cloudwatch.
+data "aws_iam_policy_document" "lambda-log-policy-doc" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    
+    resources = ["arn:aws:logs:::*"]
+  }
+}

--- a/lambda-role.tf
+++ b/lambda-role.tf
@@ -1,0 +1,9 @@
+###########################################
+############### RESOURCES #################
+###########################################
+
+#Create lambda execution role.
+resource "aws_iam_role" "lambda-role" {
+  name               = "LambdaExecutionRole"
+  assume_role_policy = data.aws_iam_policy_document.lambda-trust-policy-doc.json
+}

--- a/lambda-role.tf
+++ b/lambda-role.tf
@@ -7,3 +7,10 @@ resource "aws_iam_role" "lambda-role" {
   name               = "LambdaExecutionRole"
   assume_role_policy = data.aws_iam_policy_document.lambda-trust-policy-doc.json
 }
+
+# Attach an inline resource Policy for Lambda role.
+resource "aws_iam_role_policy" "lambda-log-permissions" {
+  name   = "lambdaExecutionRolePolicy"
+  role   = aws_iam_role.lambda-role.id
+  policy = data.aws_iam_policy_document.lambda-log-policy-doc.json
+}

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,4 @@
+output "LambdaExecutionRoleArn" {
+  value = aws_iam_role.lambda-role.arn
+  sensitive = true
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}


### PR DESCRIPTION
## Context

Lambda needs an Execution Role in order to interact with AWS resources e.g Logging to Cloudwatch etc. Therefore this PR:

-  Create an AWS Execution Role, and 
- Creates inline Resource Policy for the Execution Role.