### PR TITLE
Intergrate an API Gateway with a Lambda service

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.4.0"
+  hashes = [
+    "h1:EtN1lnoHoov3rASpgGmh6zZ/W6aRCTgKC7iMwvFY1yc=",
+    "zh:18e408596dd53048f7fc8229098d0e3ad940b92036a24287eff63e2caec72594",
+    "zh:392d4216ecd1a1fd933d23f4486b642a8480f934c13e2cae3c13b6b6a7e34a7b",
+    "zh:655dd1fa5ca753a4ace21d0de3792d96fff429445717f2ce31c125d19c38f3ff",
+    "zh:70dae36c176aa2b258331ad366a471176417a94dd3b4985a911b8be9ff842b00",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7d8c8e3925f1e21daf73f85983894fbe8868e326910e6df3720265bc657b9c9c",
+    "zh:a032ec0f0aee27a789726e348e8ad20778c3a1c9190ef25e7cff602c8d175f44",
+    "zh:b8e50de62ba185745b0fe9713755079ad0e9f7ac8638d204de6762cc36870410",
+    "zh:c8ad0c7697a3d444df21ff97f3473a8604c8639be64afe3f31b8ec7ad7571e18",
+    "zh:df736c5a2a7c3a82c5493665f659437a22f0baf8c2d157e45f4dd7ca40e739fc",
+    "zh:e8ffbf578a0977074f6d08aa8734e36c726e53dc79894cfc4f25fadc4f45f1df",
+    "zh:efea57ff23b141551f92b2699024d356c7ffd1a4ad62931da7ed7a386aef7f1f",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version = "5.17.0"
   hashes = [

--- a/apigateway.tf
+++ b/apigateway.tf
@@ -21,3 +21,12 @@ resource "aws_api_gateway_method" "character-http-method" {
   resource_id   = aws_api_gateway_resource.character-resource.id
   rest_api_id   = aws_api_gateway_rest_api.tekken-rest-api.id
 }
+
+resource "aws_api_gateway_integration" "character-integration" {
+  integration_http_method = "POST"
+  http_method             = aws_api_gateway_method.character-http-method.http_method
+  resource_id             = aws_api_gateway_resource.character-resource.id
+  rest_api_id             = aws_api_gateway_rest_api.tekken-rest-api.id
+  uri                     = aws_lambda_function.tekken-lambda-function.invoke_arn
+  type                    = "AWS_PROXY"
+}

--- a/apigateway.tf
+++ b/apigateway.tf
@@ -30,3 +30,26 @@ resource "aws_api_gateway_integration" "character-integration" {
   uri                     = aws_lambda_function.tekken-lambda-function.invoke_arn
   type                    = "AWS_PROXY"
 }
+
+#Routing --> /characters endpoint
+resource "aws_api_gateway_resource" "characters-resource" {
+  rest_api_id = aws_api_gateway_rest_api.tekken-rest-api.id
+  parent_id   = aws_api_gateway_rest_api.tekken-rest-api.root_resource_id
+  path_part   = "characters"
+}
+
+resource "aws_api_gateway_method" "characters-http-method" {
+  authorization = "NONE"
+  http_method   = "GET"
+  resource_id   = aws_api_gateway_resource.characters-resource.id
+  rest_api_id   = aws_api_gateway_rest_api.tekken-rest-api.id
+}
+
+resource "aws_api_gateway_integration" "characters-integration" {
+  integration_http_method = "POST"
+  http_method             = aws_api_gateway_method.characters-http-method.http_method
+  resource_id             = aws_api_gateway_resource.characters-resource.id
+  rest_api_id             = aws_api_gateway_rest_api.tekken-rest-api.id
+  uri                     = aws_lambda_function.tekken-lambda-function.invoke_arn
+  type                    = "AWS_PROXY"
+}

--- a/apigateway.tf
+++ b/apigateway.tf
@@ -1,0 +1,9 @@
+#Create API Gateway
+resource "aws_api_gateway_rest_api" "tekken-rest-api" {
+  name        = "TekkenAPI"
+  description = "API to query Tekken Seven Character attributes."
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}

--- a/apigateway.tf
+++ b/apigateway.tf
@@ -14,3 +14,10 @@ resource "aws_api_gateway_resource" "character-resource" {
   parent_id   = aws_api_gateway_rest_api.tekken-rest-api.root_resource_id
   path_part   = "character"
 }
+
+resource "aws_api_gateway_method" "character-http-method" {
+  authorization = "NONE"
+  http_method   = "GET"
+  resource_id   = aws_api_gateway_resource.character-resource.id
+  rest_api_id   = aws_api_gateway_rest_api.tekken-rest-api.id
+}

--- a/apigateway.tf
+++ b/apigateway.tf
@@ -7,3 +7,10 @@ resource "aws_api_gateway_rest_api" "tekken-rest-api" {
     types = ["REGIONAL"]
   }
 }
+
+#Routing --> /character endpoint
+resource "aws_api_gateway_resource" "character-resource" {
+  rest_api_id = aws_api_gateway_rest_api.tekken-rest-api.id
+  parent_id   = aws_api_gateway_rest_api.tekken-rest-api.root_resource_id
+  path_part   = "character"
+}

--- a/app/tekken-handler.py
+++ b/app/tekken-handler.py
@@ -1,32 +1,56 @@
 import json
 
-def lambda_handler(event: object, context: object = None):
+def lambda_handler(event, context = None):
 
-    character_name: str = event["payload"]["name"]
-    http_method: str = event["method"]
-    path: str = event["path"]
+    method = event["httpMethod"]
+    path = event["path"]
     
     db = {
-        "Noctis": {
-            "powerlevel": 6,
-            "special": "SuperHopkick"
+        "#Noctis": {
+            "name": "Noctis",
+            "powerLevel": 6,
+            "ability": {
+                "evasiveness": 6,
+                "wallCarry": 8,
+                "mobility": 8,
+                "ComboDamage": 5,
+                "ThrowGame": 8
+            },
         },
-        "Anna": {
+        "#Akuma": {
+            "name": "Akuma",
             "powerlevel": 8,
-            "special": "superstrike"
+            "ability": {
+                "evasiveness": 7,
+                "wallCarry": 9,
+                "mobility": 4,
+                "ComboDamage": 10,
+                "ThrowGame": 5
+            }
         }
     }
 
-    if http_method == "GET" and path == "/api/v1/character":
+    
+    if method == "GET" and path == "/character":
 
-        character_data = db.get(character_name)
+        name = event["queryStringParameters"]["name"]
+        character_data = db[name]
 
         return {
             "statusCode": 200,
-            "body": json.dumps(character_data)
+            "body": json.dumps(character_data, indent=2)
         }
-
+        
+    if method == "GET" and path == "/characters":
+        return {
+          "statusCode": 200,
+          "body": json.dumps(db, indent=2)
+        } 
+        
+    
     return {
         "statusCode": 404,
-        "body": "Cannot retrieve data."
+        "body": json.dumps({
+            "message": "resource cannot be found."
+        })
     }

--- a/lambdas.tf
+++ b/lambdas.tf
@@ -22,3 +22,12 @@ resource "aws_lambda_function" "tekken-lambda-function" {
   runtime          = "python3.11"
   depends_on       = [aws_iam_role.lambda-role]
 }
+
+# Create resource based policy statement for invoking a http method.
+resource "aws_lambda_permission" "invokefunction" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.tekken-lambda-function.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "arn:aws:execute-api:${local.region}:${local.account_id}:${local.api_id}/*/*"
+}

--- a/lambdas.tf
+++ b/lambdas.tf
@@ -1,10 +1,19 @@
 ###########################################
+############### LOCALS ####################
+###########################################
+
+locals {
+  api_id     = aws_api_gateway_rest_api.tekken-rest-api.id
+  account_id = var.account_id
+  region     = var.region
+}
+
+###########################################
 ############### RESOURCES #################
 ###########################################
 
 # Lambda for main tekken API.
 resource "aws_lambda_function" "tekken-lambda-function" {
-
   filename         = "${path.module}/app/tekken-handler.zip"
   function_name    = "TekkenLambdaFunction"
   role             = aws_iam_role.lambda-role.arn

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,9 @@
+variable "region" {
+  type        = string
+  description = "AWS region resources are created under."
+}
+
+variable "account_id" {
+  type        = string
+  description = "ID of the AWS account."
+}


### PR DESCRIPTION
## Context

This PR creates a deployable API Gateway and integrates it with a Lambda service. The APIGW is responsible for routing traffic to it's intended path. There are two routes handle by APIGW namely: 
- `/character` for fetching data on an individual character and it's attributes.
- `/characters` for fetching a list of character and their attributes.